### PR TITLE
Set dimensions on encoding to fix IndexError on decoding

### DIFF
--- a/geobuf/encode.py
+++ b/geobuf/encode.py
@@ -30,6 +30,7 @@ class Encoder:
     def encode(self, data_json, precision=6, dim=2):
         obj = self.json = data_json
         data = self.data = geobuf_pb2.Data()
+        data.dimensions = dim
 
         self.precision = precision
         self.dim = dim

--- a/test/test_coding.py
+++ b/test/test_coding.py
@@ -79,3 +79,35 @@ def test_circle_accumulating_error():
     ring_orig = [round_coord(coord) for coord in feature['coordinates'][0][0]]
     ring_round_tripped = [round_coord(coord) for coord in round_tripped['coordinates'][0][0]]
     assert ring_round_tripped == ring_orig
+
+
+def test_dimensions():
+    """
+    Generate a line of 8 points. Each point is a coordinate with an altitude.
+    Ensure dim parameter allows to encode and decode a geometry.
+
+    Using dim=2 will reduce the coordinates by removing the altitude.
+    Using dim=3 must conserve the altitude
+    """
+    feature = {
+        'type': 'MultiPolygon',
+        'coordinates': [[[]]],
+    }
+    points = 8
+    # Z coordinates[0, 1, 2, 3, ... , 8, 0]
+    feature['coordinates'][0][0] = [[0, 0, i] for i in range(0, points + 1)]
+    feature['coordinates'][0][0].append([0, 0, 0])
+
+    pbf = Encoder().encode(feature, dim=2)
+    dim2 = Decoder().decode(pbf)
+
+    dim2_orig = [[x, y] for x, y, z in feature['coordinates'][0][0]]
+    dim2 = dim2['coordinates'][0][0]
+    assert dim2 == dim2_orig
+
+    pbf = Encoder().encode(feature, dim=3)
+    dim3 = Decoder().decode(pbf)
+
+    dim_orig = feature['coordinates'][0][0]
+    dim3 = dim3['coordinates'][0][0]
+    assert dim3 == dim_orig


### PR DESCRIPTION
This is necessary for the decoding to handle coordinates with Z

# Current behavior

Causes IndexError on decoding with some sort of multilevel data

Encoding a geojson containing a FeatureCollection or using other complexe structure like MultiPoligon and decoding it fails if it contains 3 dimensions coordinates and raise the following error:
```
geobuf/decode.py:122: in decode_line
    p = [p0[j] + coords[i + j] for j in r]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

.0 = <range_iterator object at 0x7f04270437e0>

>   p = [p0[j] + coords[i + j] for j in r]
E   IndexError: list index (27) out of range
```

Causes strange behaviour with simple data like LineString

Decoded pbf becomes a 2d coordinates with extra coordinates.

Example
encoding: `LineString([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])`
becomes: `LineString([1.0, 2.0,], [4.0, 5.0], [7.0, 8.0]])`

Fixes #48